### PR TITLE
Fixed  error occur when compiling with llvm-10

### DIFF
--- a/clang/makefile
+++ b/clang/makefile
@@ -6,7 +6,7 @@ ifeq ($(LLVM_LDFLAGS),)
 $(error Could not run $(LLVM_CONFIG).  Please make sure it is available on your PATH \
 or specify the absolute path of the llvm-config executable in the LLVM_CONFIG environment variable)
 endif
-CXXFLAGS := $(shell ${LLVM_CONFIG} --cxxflags) -fPIC -O2 -std=c++11 -Wall -Wno-strict-aliasing $(if $(DEBUG),-O0 -g)
+CXXFLAGS :=  -std=c++11 $(shell ${LLVM_CONFIG} --cxxflags) -fPIC -O2 -Wall -Wno-strict-aliasing $(if $(DEBUG),-O0 -g)
 
 ifeq ($(UNAME_S),Linux)
     LDFLAGS := -fPIC -g -Wl,-rpath -Wl,'$$ORIGIN' $(LLVM_LDFLAGS) -shared


### PR DESCRIPTION
Command ` llvm-config --cxxflags` outputs following flags in llvm-10:
```
-I/usr/lib/llvm-10/include -std=c++14   -fno-exceptions -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
```
Note that flag `-std=c++14` sets the cxx standard to 14. But this setting will be overwritten by the flag set in the `Makefile`.

So I modified the order of flags to pass the compilation.